### PR TITLE
Add trait to handle virtual staking event listeners

### DIFF
--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -292,6 +292,11 @@ pub mod pallet {
 		#[pallet::no_default_bounds]
 		type EventListeners: sp_staking::OnStakingUpdate<Self::AccountId, BalanceOf<Self>>;
 
+		/// Something that listens to staking updates for virtual stakers and performs actions based
+		/// on the data it receives.
+		#[pallet::no_default_bounds]
+		type VirtualEventListeners: sp_staking::OnVirtualStakingUpdate<Self::AccountId, BalanceOf<Self>>;
+
 		/// `DisablingStragegy` controls how validators are disabled
 		#[pallet::no_default_bounds]
 		type DisablingStrategy: DisablingStrategy<Self>;
@@ -342,6 +347,7 @@ pub mod pallet {
 			type MaxUnlockingChunks = ConstU32<32>;
 			type MaxControllersInDeprecationBatch = ConstU32<100>;
 			type EventListeners = ();
+			type VirtualEventListeners = ();
 			type DisablingStrategy = crate::UpToLimitDisablingStrategy;
 			#[cfg(feature = "std")]
 			type BenchmarkingConfig = crate::TestBenchmarkingConfig;

--- a/substrate/primitives/staking/src/lib.rs
+++ b/substrate/primitives/staking/src/lib.rs
@@ -158,6 +158,23 @@ pub trait OnStakingUpdate<AccountId, Balance> {
 	fn on_withdraw(_stash: &AccountId, _amount: Balance) {}
 }
 
+/// A generic virtual staking event listener.
+///
+/// Note that the interface is designed in a way that the events are fired post-action, so any
+/// pre-action data that is needed needs to be passed to interface methods. The rest of the data can
+/// be retrieved by using `StakingInterface`.
+#[impl_trait_for_tuples::impl_for_tuples(10)]
+pub trait OnVirtualStakingUpdate<AccountId, Balance> {
+	fn on_virtual_nominator_payout(
+		_stash: &AccountId,
+		_dest: &AccountId,
+		_amount: Balance,
+		_validator: &AccountId,
+		_era: EraIndex,
+		_page: Page
+	) {}
+}
+
 /// A generic representation of a staking implementation.
 ///
 /// This interface uses the terminology of NPoS, but it is aims to be generic enough to cover other


### PR DESCRIPTION
### Description

This pull request introduces a new trait `OnVirtualStakingUpdate` to support event listeners for virtual staking updates. The trait is integrated into the staking pallet, enabling custom actions to be triggered on virtual staker payouts. This enhancement allows for better extensibility and tailored responses to specific staking events.

### Guidelines Checklist

- [x] Documentation has been updated with usage details where applicable.
- [x] The code adheres to the project's style guidelines.