### PR TITLE
Add validator whitelist

### DIFF
--- a/substrate/frame/staking/src/benchmarking.rs
+++ b/substrate/frame/staking/src/benchmarking.rs
@@ -961,6 +961,33 @@ benchmarks! {
 		assert_eq!(Staking::<T>::inspect_bond_state(&stash), Ok(LedgerIntegrityState::Ok));
 	}
 
+	add_to_validator_whitelist {
+    	let stash: T::AccountId = create_funded_user::<T>("whitelist_stash", USER_SEED, 100);
+    	assert!(!ValidatorWhitelist::<T>::contains_key(&stash));
+	}: _(RawOrigin::Root, stash.clone())
+	verify {
+		assert!(ValidatorWhitelist::<T>::contains_key(&stash));
+		assert_eq!(ValidatorWhitelist::<T>::get(&stash), true);
+	}
+	
+	remove_from_validator_whitelist {
+    	let stash: T::AccountId = create_funded_user::<T>("whitelist_stash", USER_SEED, 100);
+    	ValidatorWhitelist::<T>::insert(&stash, true);
+    	assert!(ValidatorWhitelist::<T>::contains_key(&stash));
+	}: _(RawOrigin::Root, stash.clone())
+	verify {
+		assert!(!ValidatorWhitelist::<T>::contains_key(&stash));
+	}
+	
+	set_is_validator_whitelist_enabled {
+		let is_enabled = true;
+		IsValidatorWhitelistEnabled::<T>::put(!is_enabled);
+		assert_eq!(IsValidatorWhitelistEnabled::<T>::get(), !is_enabled);
+	}: _(RawOrigin::Root, is_enabled)
+	verify {
+		assert_eq!(IsValidatorWhitelistEnabled::<T>::get(), is_enabled);
+	}
+
 	impl_benchmark_test_suite!(
 		Staking,
 		crate::mock::ExtBuilder::default().has_stakers(true),

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -797,10 +797,13 @@ pub mod pallet {
 					RewardDestination::Staked,
 				));
 				frame_support::assert_ok!(match status {
-					crate::StakerStatus::Validator => <Pallet<T>>::validate(
-						T::RuntimeOrigin::from(Some(stash.clone()).into()),
-						Default::default(),
-					),
+					crate::StakerStatus::Validator => {
+						ValidatorWhitelist::<T>::insert(stash.clone(), true);
+						<Pallet<T>>::validate(
+							T::RuntimeOrigin::from(Some(stash.clone()).into()),
+							Default::default(),
+						)
+					},
 					crate::StakerStatus::Nominator(votes) => <Pallet<T>>::nominate(
 						T::RuntimeOrigin::from(Some(stash.clone()).into()),
 						votes.iter().map(|l| T::Lookup::unlookup(l.clone())).collect(),

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -2298,7 +2298,7 @@ pub mod pallet {
 		/// # Emits
 		/// - `ValidatorWhitelistUpdated { stash, whitelisted: true }`
 		#[pallet::call_index(30)]
-		#[pallet::weight(T::WeightInfo::set_validator_count())]
+		#[pallet::weight(T::WeightInfo::add_to_validator_whitelist())]
 		pub fn add_to_validator_whitelist(
 			origin: OriginFor<T>,
 			stash: T::AccountId,
@@ -2324,7 +2324,7 @@ pub mod pallet {
 		/// # Emits
 		/// - `ValidatorWhitelistUpdated { stash, whitelisted: false }`
 		#[pallet::call_index(31)]
-		#[pallet::weight(T::WeightInfo::set_validator_count())]
+		#[pallet::weight(T::WeightInfo::remove_from_validator_whitelist())]
 		pub fn remove_from_validator_whitelist(
 			origin: OriginFor<T>,
 			stash: T::AccountId,
@@ -2350,7 +2350,7 @@ pub mod pallet {
 		/// # Emits
 		/// - `ValidatorWhitelistToggled { is_enabled }`
 		#[pallet::call_index(32)]
-		#[pallet::weight(T::WeightInfo::set_validator_count())]
+		#[pallet::weight(T::WeightInfo::set_is_validator_whitelist_enabled())]
 		pub fn set_is_validator_whitelist_enabled(
 			origin: OriginFor<T>,
 			is_enabled: bool,

--- a/substrate/frame/staking/src/weights.rs
+++ b/substrate/frame/staking/src/weights.rs
@@ -83,6 +83,9 @@ pub trait WeightInfo {
 	fn force_apply_min_commission() -> Weight;
 	fn set_min_commission() -> Weight;
 	fn restore_ledger() -> Weight;
+	fn add_to_validator_whitelist() -> Weight;
+	fn remove_from_validator_whitelist() -> Weight;
+	fn set_is_validator_whitelist_enabled() -> Weight;
 }
 
 /// Weights for `pallet_staking` using the Substrate node and recommended hardware.
@@ -834,6 +837,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
+
+	fn add_to_validator_whitelist() -> Weight {
+		Weight::from_parts(2_802_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+
+	fn remove_from_validator_whitelist() -> Weight {
+		Weight::from_parts(2_802_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+
+	fn set_is_validator_whitelist_enabled() -> Weight {
+		Weight::from_parts(2_802_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 }
 
 // For backwards compatibility and tests.
@@ -1583,5 +1601,20 @@ impl WeightInfo for () {
 		Weight::from_parts(45_611_000, 4764)
 			.saturating_add(RocksDbWeight::get().reads(5_u64))
 			.saturating_add(RocksDbWeight::get().writes(4_u64))
+	}
+
+	fn add_to_validator_whitelist() -> Weight {
+		Weight::from_parts(2_802_000, 0)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+
+	fn remove_from_validator_whitelist() -> Weight {
+		Weight::from_parts(2_802_000, 0)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+
+	fn set_is_validator_whitelist_enabled() -> Weight {
+		Weight::from_parts(2_802_000, 0)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 }


### PR DESCRIPTION
This PR adds a validator whitelist and a mechanism to enable or disable it. When enabled, only accounts in the whitelist can validate. When disabled, anyone can become a validator.

There are three new pallet calls:
```rust
// add an account to the whitelist
pub fn add_to_validator_whitelist(origin: OriginFor<T>, stash: T::AccountId) -> DispatchResult
// remove an account from the whitelist
pub fn remove_from_validator_whitelist(origin: OriginFor<T>, stash: T::AccountId) -> DispatchResult
// enable or disable the whitelist
pub fn set_is_validator_whitelist_enabled(origin: OriginFor<T>, is_enabled: bool) -> DispatchResult
```

This PR also modifies the `chill_other` pallet call so that the root account can always use it, regardless of whether the threshold rules have been met. This allows the ZenChain admin to remove an active validator's account from the whitelist and then chill the account so it is no longer a validator.

Issue: https://github.com/zenchain-protocol/zenchain-node/issues/508