### PR TITLE
Skip rewards if treasury is empty

### DIFF
--- a/polkadot/runtime/westend/src/weights/pallet_staking.rs
+++ b/polkadot/runtime/westend/src/weights/pallet_staking.rs
@@ -826,4 +826,16 @@ impl<T: frame_system::Config> pallet_staking::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
+
+	fn add_to_validator_whitelist() -> Weight {
+		Weight::zero()
+	}
+
+	fn remove_from_validator_whitelist() -> Weight {
+		Weight::zero()
+	}
+
+	fn set_is_validator_whitelist_enabled() -> Weight {
+		Weight::zero()
+	}
 }

--- a/substrate/frame/balances/src/impl_treasury.rs
+++ b/substrate/frame/balances/src/impl_treasury.rs
@@ -1,0 +1,12 @@
+use frame_support::traits::GetTreasury;
+use crate::{Config, Pallet};
+
+// Default GetTreasury implementation for testing.
+impl<T: Config<I>, I: 'static> GetTreasury<T::AccountId> for Pallet<T, I>
+where
+    T::AccountId: Default
+{
+    fn get_treasury() -> T::AccountId {
+        T::AccountId::default()
+    }
+}

--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -149,8 +149,10 @@ pub mod migration;
 mod tests;
 mod types;
 pub mod weights;
+mod impl_treasury;
 
 extern crate alloc;
+extern crate core;
 
 use alloc::vec::Vec;
 use codec::{Codec, MaxEncodedLen};

--- a/substrate/frame/election-provider-multi-phase/src/benchmarking.rs
+++ b/substrate/frame/election-provider-multi-phase/src/benchmarking.rs
@@ -191,6 +191,8 @@ fn set_up_data_provider<T: Config>(v: u32, t: u32) {
 }
 
 frame_benchmarking::benchmarks! {
+	where_clause { where <T as frame_system::Config>::AccountId: Default }
+	
 	on_initialize_nothing {
 		assert!(<MultiPhase<T>>::current_phase().is_off());
 	}: {
@@ -222,7 +224,8 @@ frame_benchmarking::benchmarks! {
 
 	finalize_signed_phase_accept_solution {
 		let receiver = account("receiver", 0, SEED);
-		let initial_balance = T::Currency::minimum_balance() + 10u32.into();
+		let ed = T::Currency::minimum_balance();
+		let initial_balance = ed + 10u32.into();
 		T::Currency::make_free_balance_be(&receiver, initial_balance);
 		let ready = Default::default();
 		let deposit: BalanceOf<T> = 10u32.into();
@@ -230,14 +233,20 @@ frame_benchmarking::benchmarks! {
 		let reward: BalanceOf<T> = T::SignedRewardBase::get();
 		let call_fee: BalanceOf<T> = 30u32.into();
 
+		let treasury_account = T::AccountId::default();
+		let treasury_balance = ed + call_fee + reward;
+		T::Currency::make_free_balance_be(&treasury_account, treasury_balance);
+
 		assert_ok!(T::Currency::reserve(&receiver, deposit));
-		assert_eq!(T::Currency::free_balance(&receiver), T::Currency::minimum_balance());
+		assert_eq!(T::Currency::free_balance(&receiver), ed);
+		assert_eq!(T::Currency::free_balance(&treasury_account), treasury_balance);
 	}: {
 		<MultiPhase<T>>::finalize_signed_phase_accept_solution(
 			ready,
 			&receiver,
 			deposit,
-			call_fee
+			call_fee,
+			treasury_balance
 		)
 	} verify {
 		assert_eq!(

--- a/substrate/frame/election-provider-multi-phase/src/lib.rs
+++ b/substrate/frame/election-provider-multi-phase/src/lib.rs
@@ -572,6 +572,7 @@ pub mod pallet {
 	use super::*;
 	use frame_election_provider_support::{InstantElectionProvider, NposSolver};
 	use frame_support::{pallet_prelude::*, traits::EstimateCallFee};
+	use frame_support::traits::GetTreasury;
 	use frame_system::pallet_prelude::*;
 	use sp_runtime::traits::Convert;
 
@@ -582,7 +583,9 @@ pub mod pallet {
 			+ TryInto<Event<Self>>;
 
 		/// Currency type.
-		type Currency: ReservableCurrency<Self::AccountId> + Currency<Self::AccountId>;
+		type Currency: ReservableCurrency<Self::AccountId>
+			+ Currency<Self::AccountId>
+			+ GetTreasury<Self::AccountId>;
 
 		/// Something that can predict the fee of a call. Used to sensibly distribute rewards.
 		type EstimateCallFee: EstimateCallFee<Call<Self>, BalanceOf<Self>>;

--- a/substrate/frame/election-provider-multi-phase/src/mock.rs
+++ b/substrate/frame/election-provider-multi-phase/src/mock.rs
@@ -590,6 +590,8 @@ impl ExtBuilder {
 				(105, 100),
 				(999, 100),
 				(9999, 100),
+				// treasury
+				(0, 100)
 			],
 		}
 		.assimilate_storage(&mut storage);

--- a/substrate/frame/election-provider-multi-phase/src/signed.rs
+++ b/substrate/frame/election-provider-multi-phase/src/signed.rs
@@ -404,6 +404,10 @@ impl<T: Config> Pallet<T> {
 		let mut found_solution = false;
 		let mut weight = T::DbWeight::get().reads(1);
 
+		let treasury = T::Currency::get_treasury();
+		let mut treasury_balance = T::Currency::free_balance(&treasury);
+		weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 0));
+
 		let SolutionOrSnapshotSize { voters, targets } =
 			Self::snapshot_metadata().unwrap_or_default();
 
@@ -426,12 +430,14 @@ impl<T: Config> Pallet<T> {
 			weight = weight.saturating_add(feasibility_weight);
 			match Self::feasibility_check(raw_solution, ElectionCompute::Signed) {
 				Ok(ready_solution) => {
-					Self::finalize_signed_phase_accept_solution(
+					let minted = Self::finalize_signed_phase_accept_solution(
 						ready_solution,
 						&who,
 						deposit,
 						call_fee,
+						treasury_balance,
 					);
+					treasury_balance = treasury_balance.saturating_sub(minted);
 					found_solution = true;
 					log!(debug, "finalized_signed: found a valid solution");
 
@@ -457,11 +463,12 @@ impl<T: Config> Pallet<T> {
 		for SignedSubmission { who, deposit, call_fee, .. } in
 			all_submissions.drain_submitted_order()
 		{
-			if refund_count < max_refunds {
+			if refund_count < max_refunds && treasury_balance >= call_fee {
 				// Refund fee
 				let positive_imbalance = T::Currency::deposit_creating(&who, call_fee);
 				T::RewardHandler::on_unbalanced(positive_imbalance);
 				refund_count += 1;
+				treasury_balance = treasury_balance.saturating_sub(call_fee);
 			}
 
 			// Unreserve deposit
@@ -488,39 +495,46 @@ impl<T: Config> Pallet<T> {
 	/// Extracted to facilitate with weight calculation.
 	///
 	/// Infallible
+	///
+	/// Returns total amount minted (call fee + reward)
 	pub fn finalize_signed_phase_accept_solution(
 		ready_solution: ReadySolution<T::AccountId, T::MaxWinners>,
 		who: &T::AccountId,
 		deposit: BalanceOf<T>,
 		call_fee: BalanceOf<T>,
-	) {
+		treasury_balance: BalanceOf<T>,
+	) -> BalanceOf<T> {
 		// write this ready solution.
 		<QueuedSolution<T>>::put(ready_solution);
-
-		let reward = T::SignedRewardBase::get();
-		// emit reward event
-		Self::deposit_event(crate::Event::Rewarded { account: who.clone(), value: reward });
 
 		// Unreserve deposit.
 		let _remaining = T::Currency::unreserve(who, deposit);
 		debug_assert!(_remaining.is_zero());
 
-		// Calculate total reward + call fee
-		let mut total_reward = reward.saturating_add(call_fee);
+		let mut reward = T::SignedRewardBase::get();
+		let mut total_mint= reward.saturating_add(call_fee);
 
 		// only issue rewards if they are available in the treasury
-		let treasury = T::Currency::get_treasury();
-		let treasury_balance = T::Currency::free_balance(&treasury);
-		if treasury_balance < total_reward {
-			total_reward = treasury_balance;
+		if treasury_balance < total_mint {
+			total_mint = treasury_balance;
+			if treasury_balance <= call_fee {
+				reward = BalanceOf::<T>::zero();
+			} else {
+				reward = treasury_balance.saturating_sub(call_fee);
+			}
 		}
 
+		// emit reward event
+		Self::deposit_event(crate::Event::Rewarded { account: who.clone(), value: reward });
+
 		// Reward and refund the call fee.
-		if !total_reward.is_zero() {
+		if !total_mint.is_zero() {
 			let positive_imbalance =
-				T::Currency::deposit_creating(who, total_reward);
+				T::Currency::deposit_creating(who, total_mint);
 			T::RewardHandler::on_unbalanced(positive_imbalance);
 		}
+
+		total_mint
 	}
 
 	/// Helper function for the case where a solution is accepted in the rejected phase.
@@ -740,6 +754,70 @@ mod tests {
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 99, value: 7 }
+				]
+			);
+		})
+	}
+
+	#[test]
+	fn good_solution_is_partially_rewarded_if_treasury_almost_empty() {
+		ExtBuilder::default().build_and_execute(|| {
+			assert_ok!(Balances::force_set_balance(RuntimeOrigin::root(), 0, 10));
+
+			roll_to_signed();
+			assert!(MultiPhase::current_phase().is_signed());
+
+			let solution = raw_solution();
+			assert_eq!(balances(&99), (100, 0));
+
+			assert_ok!(MultiPhase::submit(RuntimeOrigin::signed(99), Box::new(solution)));
+			assert_eq!(balances(&99), (95, 5));
+
+			assert!(MultiPhase::finalize_signed_phase());
+			assert_eq!(balances(&99), (100 + 2 + 8, 0));
+
+			assert_eq!(
+				multi_phase_events(),
+				vec![
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						origin: Some(99),
+						prev_ejected: false
+					},
+					Event::Rewarded { account: 99, value: 2 }
+				]
+			);
+		})
+	}
+
+	#[test]
+	fn good_solution_is_not_rewarded_if_treasury_empty() {
+		ExtBuilder::default().build_and_execute(|| {
+			assert_ok!(Balances::force_set_balance(RuntimeOrigin::root(), 0, 0));
+
+			roll_to_signed();
+			assert!(MultiPhase::current_phase().is_signed());
+
+			let solution = raw_solution();
+			assert_eq!(balances(&99), (100, 0));
+
+			assert_ok!(MultiPhase::submit(RuntimeOrigin::signed(99), Box::new(solution)));
+			assert_eq!(balances(&99), (95, 5));
+
+			assert!(MultiPhase::finalize_signed_phase());
+			assert_eq!(balances(&99), (100, 0));
+
+			assert_eq!(
+				multi_phase_events(),
+				vec![
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						origin: Some(99),
+						prev_ejected: false
+					},
+					Event::Rewarded { account: 99, value: 0 }
 				]
 			);
 		})

--- a/substrate/frame/staking/src/mock.rs
+++ b/substrate/frame/staking/src/mock.rs
@@ -461,8 +461,8 @@ impl ExtBuilder {
 				(71, self.balance_factor * 2000),
 				(80, self.balance_factor),
 				(81, self.balance_factor * 2000),
-				// This allows us to have a total_payout different from 0.
-				(999, 1_000_000_000_000),
+				// Funds treasury and allows us to have a total_payout different from 0.
+				(0, 1_000_000_000_000),
 			],
 		}
 		.assimilate_storage(&mut storage);

--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -29,6 +29,7 @@ use frame_support::{
 	traits::{
 		Currency, Defensive, DefensiveSaturating, EstimateNextNewSession, Get, Imbalance,
 		InspectLockableCurrency, Len, LockableCurrency, OnUnbalanced, TryCollect, UnixTime,
+		GetTreasury
 	},
 	weights::Weight,
 };
@@ -590,8 +591,17 @@ impl<T: Config> Pallet<T> {
 				MaxStakedRewards::<T>::get().unwrap_or(Percent::from_percent(100));
 
 			// apply cap to validators payout and add difference to remainder.
-			let validator_payout = validator_payout.min(max_staked_rewards * total_payout);
-			let remainder = total_payout.saturating_sub(validator_payout);
+			let mut validator_payout = validator_payout.min(max_staked_rewards * total_payout);
+			let mut remainder = total_payout.saturating_sub(validator_payout);
+
+			// only issue rewards if they are available in the treasury
+			let treasury = T::Currency::get_treasury();
+			let treasury_balance = T::Currency::free_balance(&treasury);
+			if treasury_balance < validator_payout {
+				let difference = validator_payout.saturating_sub(treasury_balance);
+				remainder = remainder.saturating_add(difference);
+				validator_payout = treasury_balance;
+			}
 
 			Self::deposit_event(Event::<T>::EraPaid {
 				era_index: active_era.index,
@@ -600,7 +610,9 @@ impl<T: Config> Pallet<T> {
 			});
 
 			// Set ending era reward.
-			<ErasValidatorReward<T>>::insert(&active_era.index, validator_payout);
+			if !validator_payout.is_zero() {
+				<ErasValidatorReward<T>>::insert(&active_era.index, validator_payout);
+			}
 			T::RewardRemainder::on_unbalanced(T::Currency::issue(remainder));
 
 			// Clear disabled validators.

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -26,7 +26,7 @@ use frame_support::{
 	pallet_prelude::*,
 	traits::{
 		Currency, Defensive, DefensiveSaturating, EnsureOrigin, EstimateNextNewSession, Get,
-		InspectLockableCurrency, LockableCurrency, OnUnbalanced, UnixTime, WithdrawReasons,
+		InspectLockableCurrency, LockableCurrency, OnUnbalanced, UnixTime, WithdrawReasons, GetTreasury
 	},
 	weights::Weight,
 	BoundedVec,
@@ -93,7 +93,7 @@ pub mod pallet {
 				Self::AccountId,
 				Moment = BlockNumberFor<Self>,
 				Balance = Self::CurrencyBalance,
-			> + InspectLockableCurrency<Self::AccountId>;
+			> + InspectLockableCurrency<Self::AccountId> + GetTreasury<Self::AccountId>;
 		/// Just the `Currency::Balance` type; we have this item to allow us to constrain it to
 		/// `From<u64>`.
 		type CurrencyBalance: sp_runtime::traits::AtLeast32BitUnsigned

--- a/substrate/frame/staking/src/tests.rs
+++ b/substrate/frame/staking/src/tests.rs
@@ -3924,6 +3924,109 @@ fn test_nominators_are_rewarded_for_all_exposure_page() {
 }
 
 #[test]
+fn partial_rewards_if_treasury_nearly_empty() {
+	// Test that payout_stakers work in general and that it pays the correct amount of reward.
+	ExtBuilder::default().has_stakers(false).build_and_execute(|| {
+		let balance = 1000;
+		// Track the exposure of the validator and all nominators.
+		let mut total_exposure = balance;
+		// Create a validator:
+		bond_validator(11, balance); // Default(64)
+		assert_eq!(Validators::<Test>::count(), 1);
+
+		// Create nominators, targeting stash of validators
+		for i in 0..100 {
+			let bond_amount = balance + i as Balance;
+			bond_nominator(1000 + i, bond_amount, vec![11]);
+			// with multi page reward payout, payout exposure is same as total exposure.
+			total_exposure += bond_amount;
+		}
+
+		mock::start_active_era(1);
+		Staking::reward_by_ids(vec![(11, 1)]);
+
+		// Since `MaxExposurePageSize = 64`, there are two pages of validator exposure.
+		assert_eq!(EraInfo::<Test>::get_page_count(1, &11), 2);
+
+		// compute and ensure the reward amount is greater than zero.
+		let payout = current_total_payout_for_duration(reward_time_per_era());
+
+		// we will set up the treasury to have a low balance
+		// we need to make sure that total issuance is unchanged by this movement
+		let ti_before_shenanigans = Balances::total_issuance();
+
+		// set treasury balance to a lower value than the full payout of 11_075
+		let original_treasury_balance = Balances::free_balance(0);
+		let treasury_balance_before_payout = payout.saturating_mul(50) / 100;
+		assert_ok!(
+			Balances::force_set_balance(
+				RuntimeOrigin::root(),
+				0,
+				treasury_balance_before_payout
+			)
+		);
+		// set random account's balance so that the validator payout matches estimate
+		assert_ok!(
+			Balances::force_set_balance(
+				RuntimeOrigin::root(),
+				9999,
+				original_treasury_balance.saturating_sub(treasury_balance_before_payout)
+			)
+		);
+
+		// make sure we didn't change total issuance so that the full payout amount will match the
+		// estimated payout
+		assert_eq!(ti_before_shenanigans, Balances::total_issuance());
+
+		mock::start_active_era(2);
+
+		// actual payout should be equal to treasury balance before the payout is computed on-chain
+		// because the intended payout exceeded the treasury balance
+		let actual_reward = ErasValidatorReward::<Test>::get(1).unwrap_or_default();
+		assert_eq!(actual_reward, treasury_balance_before_payout);
+		assert!(actual_reward < payout);
+
+		// verify the exposures are calculated correctly.
+		let actual_exposure_0 = EraInfo::<Test>::get_paged_exposure(1, &11, 0).unwrap();
+		assert_eq!(actual_exposure_0.total(), total_exposure);
+		assert_eq!(actual_exposure_0.own(), 1000);
+		assert_eq!(actual_exposure_0.others().len(), 64);
+		let actual_exposure_1 = EraInfo::<Test>::get_paged_exposure(1, &11, 1).unwrap();
+		assert_eq!(actual_exposure_1.total(), total_exposure);
+		// own stake is only included once in the first page
+		assert_eq!(actual_exposure_1.own(), 0);
+		assert_eq!(actual_exposure_1.others().len(), 100 - 64);
+
+		let pre_payout_total_issuance = Balances::total_issuance();
+		RewardOnUnbalanceWasCalled::set(false);
+		System::reset_events();
+
+		let controller_balance_before_p0_payout = Balances::free_balance(&11);
+		// Payout rewards for first exposure page
+		assert_ok!(Staking::payout_stakers_by_page(RuntimeOrigin::signed(1337), 11, 1, 0));
+
+		// verify `Rewarded` events are being executed
+		assert!(matches!(
+			staking_events_since_last_call().as_slice(),
+			&[
+				..,
+				Event::Rewarded { stash: 1063, dest: RewardDestination::Stash, amount: 56, .. },
+				Event::Rewarded { stash: 1064, dest: RewardDestination::Stash, amount: 56, .. },
+			]
+		));
+
+		let controller_balance_after_p0_payout = Balances::free_balance(&11);
+
+		// verify rewards have been paid out but still some left
+		assert!(Balances::total_issuance() > pre_payout_total_issuance);
+		assert!(Balances::total_issuance() < pre_payout_total_issuance + actual_reward);
+
+		// verify the validator has been rewarded
+		assert!(controller_balance_after_p0_payout > controller_balance_before_p0_payout);
+	});
+}
+
+#[test]
 fn test_multi_page_payout_stakers_by_page() {
 	// Test that payout_stakers work in general and that it pays the correct amount of reward.
 	ExtBuilder::default().has_stakers(false).build_and_execute(|| {

--- a/substrate/frame/support/src/traits.rs
+++ b/substrate/frame/support/src/traits.rs
@@ -28,7 +28,7 @@ pub use tokens::{
 	fungible, fungibles,
 	imbalance::{Imbalance, OnUnbalanced, SignedImbalance},
 	nonfungible, nonfungible_v2, nonfungibles, nonfungibles_v2, BalanceStatus,
-	ExistenceRequirement, Locker, WithdrawReasons,
+	ExistenceRequirement, Locker, WithdrawReasons, GetTreasury,
 };
 
 mod members;

--- a/substrate/frame/support/src/traits/tokens.rs
+++ b/substrate/frame/support/src/traits/tokens.rs
@@ -32,6 +32,6 @@ pub use misc::{
 	AssetId, Balance, BalanceStatus, ConversionFromAssetBalance, ConversionToAssetBalance,
 	ConvertRank, DepositConsequence, ExistenceRequirement, Fortitude, GetSalary, IdAmount, Locker,
 	Precision, Preservation, Provenance, Restriction, UnityAssetBalanceConversion,
-	UnityOrOuterConversion, WithdrawConsequence, WithdrawReasons,
+	UnityOrOuterConversion, WithdrawConsequence, WithdrawReasons, GetTreasury
 };
 pub use pay::{Pay, PayFromAccount, PaymentStatus};

--- a/substrate/frame/support/src/traits/tokens/misc.rs
+++ b/substrate/frame/support/src/traits/tokens/misc.rs
@@ -366,3 +366,9 @@ pub struct IdAmount<Id, Balance> {
 	/// Some amount for this item.
 	pub amount: Balance,
 }
+
+/// Retrieve the treasury account
+pub trait GetTreasury<AccountId> {
+	/// Retrieve the treasury account
+	fn get_treasury() -> AccountId;
+}

--- a/substrate/primitives/core/src/crypto.rs
+++ b/substrate/primitives/core/src/crypto.rs
@@ -642,6 +642,12 @@ impl FromEntropy for AccountId32 {
 	}
 }
 
+impl Default for AccountId32 {
+	fn default() -> Self {
+		Self::new([0; 32])
+	}
+}
+
 #[cfg(feature = "std")]
 pub use self::dummy::*;
 


### PR DESCRIPTION
This PR updates pallet-staking and pallet-election-provider-multi-phase to ensure that rewards are not minted unless the treasury has funds to cover them.